### PR TITLE
add imports to  `from typing[_extensions] import ...`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     rev: v4.6.0
     hooks:
       - id: check-added-large-files
-      - id: check-ast
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-executables-have-shebangs
@@ -26,7 +25,6 @@ repos:
       - id: check-vcs-permalinks
       - id: check-xml
       - id: check-yaml
-      - id: debug-statements
       - id: destroyed-symlinks
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]

--- a/examples/pep695_type_alias.pyi
+++ b/examples/pep695_type_alias.pyi
@@ -1,4 +1,9 @@
-import os
+from os import PathLike as _PathLike
+from typing import LiteralString
 
-type PathLike[S: (str, bytes)] = S | os.PathLike[S]
+type AnyStr = str | bytes
+type PathLike[S: (str, bytes)] = S | _PathLike[S]
 type RPair[RT, LT=RT] = tuple[LT, RT]  # noqa: E225  # fmt: skip
+
+TMP_DIR: PathLike[LiteralString]
+TWO_STRINGS: RPair[str]

--- a/pythoff/__init__.py
+++ b/pythoff/__init__.py
@@ -5,24 +5,27 @@ from pathlib import Path
 import libcst as cst
 import mainpy
 
-from ._pep695 import PEP695Collector, PEP695Transformer
+from ._pep695 import PEP695Collector, TypeAliasTransformer, TypingImportTransformer
 
 
 def transpile_from_string(source: str, /, *, is_pyi: bool = True) -> str:
     visitor = PEP695Collector(is_pyi=is_pyi)
     module = cst.parse_module(source)
+
     wrapper = cst.MetadataWrapper(module)
     _ = wrapper.visit(visitor)
 
-    transformer = PEP695Transformer(
-        is_pyi=is_pyi,
-        type_params=visitor.type_params,
+    alias_transformer = TypeAliasTransformer(type_params=visitor.type_params)
+    module_out = wrapper.module.visit(alias_transformer)
+
+    import_transformer = TypingImportTransformer(
         cur_imports_typing=visitor.cur_imports_typing,
         cur_imports_typing_extensions=visitor.cur_imports_typing_extensions,
         req_imports_typing=visitor.req_imports_typing,
         req_imports_typing_extensions=visitor.req_imports_typing_extensions,
     )
-    module_out = wrapper.module.visit(transformer)
+    module_out = module_out.visit(import_transformer)
+
     return module_out.code
 
 


### PR DESCRIPTION
... and refactored the transformers with `libcst.matchers`, as recommended in the libcst docs